### PR TITLE
Add PHP version constraint to Composer 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "php": ">=5.6",
-    "phpunit/phpunit": "^5.5|^6.5"
+    "phpunit/phpunit": "^5.5|^6"
   },
   "autoload": {
     "psr-4": {
@@ -22,6 +22,6 @@
     }
   },
   "scripts": {
-    "test": "php vendor/bin/phpunit -c test/phpunit.xml"
+    "test": "phpunit -c test"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     }
   ],
   "require": {
-    "phpunit/phpunit": "^5.5|^6"
+    "php": ">=5.6",
+    "phpunit/phpunit": "^5.5|^6.5"
   },
   "autoload": {
     "psr-4": {
@@ -21,6 +22,6 @@
     }
   },
   "scripts": {
-    "test": "phpunit -c test"
+    "test": "php vendor/bin/phpunit -c test/phpunit.xml"
   }
 }


### PR DESCRIPTION
It's just for this [issue](https://github.com/ScriptFUSION/PHPUnit-Immediate-Exception-Printer/issues/1).