### PR TITLE
Fix #17 - Error suppression operator is not fully honoured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 !/.github/
 /vendor/
 /composer.lock
-/**/.phpunit.result.cache
+*.cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !/.github/
 /vendor/
 /composer.lock
+/**/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The printer's capabilities are exploited via `CapabilitiesTest`. However, this t
 
 The real tests, also known as *functional tests*, are located in `test/functional`, written in PHPT format. PHPT is a [scarcely documented format](http://qa.php.net/phpt_details.php) designed to support [testing PHP itself](https://qa.php.net/write-test.php). An undocumented feature of PHPUnit is its limited support for a subset of the PHPT test specification, which we exploit to test PHPUnit itself with our printer implementation loaded.
 
-To run the tests, simply specify `vendor/bin/phpunit -c test` on the command line from the project directory. By default, we run all the functional PHPT tests. To run `CapabilitiesTest` instead, specify `vendor/bin/phpunit -c test test/CapabilitiesTest`.
+To run the tests, simply specify `vendor/bin/phpunit -c test` on the command line from the project directory. By default, we run all the functional PHPT tests. To run `CapabilitiesTest` instead, specify `vendor/bin/phpunit -c test test/CapabilitiesTest.php`.
 
 ### Writing a functional test
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -85,7 +85,9 @@ final class Printer implements Tracer
             $this->trace = Trace::fromEvent($event);
         }
         if ($event instanceof PhpWarningTriggered) {
-            $this->status ??= TestStatus::Warning;
+            if (!$event->wasSuppressed()) {
+                $this->status ??= TestStatus::Warning;
+            }
 
             $this->trace = Trace::fromEvent($event);
         }

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -80,7 +80,9 @@ final class Printer implements Tracer
             $this->trace = new Trace($event->message(), $event->test()->file(), $event->test()->line());
         }
         if ($event instanceof PhpNoticeTriggered) {
-            $this->status ??= TestStatus::Notice;
+            if (!$event->wasSuppressed()) {
+                $this->status ??= TestStatus::Notice;
+            }
 
             $this->trace = Trace::fromEvent($event);
         }
@@ -92,7 +94,9 @@ final class Printer implements Tracer
             $this->trace = Trace::fromEvent($event);
         }
         if ($event instanceof PhpDeprecationTriggered) {
-            $this->status ??= TestStatus::Deprecated;
+            if (!$event->wasSuppressed()) {
+                $this->status ??= TestStatus::Deprecated;
+            }
 
             $this->trace = Trace::fromEvent($event);
         }

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -56,6 +56,14 @@ final class CapabilitiesTest extends TestCase
         self::assertTrue(true);
     }
 
+    public function testSilencedNotice(): void
+    {
+        // Only variables should be assigned by reference.
+        @$foo = &self::provideData();
+
+        self::assertTrue(true);
+    }
+
     public function testWarning(): void
     {
         // foreach() argument must be of type array|object.
@@ -78,6 +86,14 @@ final class CapabilitiesTest extends TestCase
             function serialize() {}
             function unserialize(string $data) {}
         };
+
+        self::assertTrue(true);
+    }
+
+    public function testSilencedDeprecation(): void
+    {
+        // Passing null to parameter #1 ($string) of type string is deprecated
+        @trim(null);
 
         self::assertTrue(true);
     }

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -92,7 +92,7 @@ final class CapabilitiesTest extends TestCase
 
     public function testSilencedDeprecation(): void
     {
-        // Passing null to parameter #1 ($string) of type string is deprecated
+        // Passing null to parameter #1 ($string) of type string is deprecated.
         @trim(null);
 
         self::assertTrue(true);

--- a/test/functional/deprecation silenced.phpt
+++ b/test/functional/deprecation silenced.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Tests that when a test generates a deprecation that is suppressed, the deprecation is not printed.
+
+--ARGS--
+-c test --colors=always test/CapabilitiesTest.php --filter ::testSilencedDeprecation$
+
+--FILE_EXTERNAL--
+../PHPUnit runner.php
+
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s
+
+100% . [32;1mScriptFUSIONTest\Pip\CapabilitiesTest::testSilencedDeprecation[0m [32m(%d ms)[0m
+
+
+Time: %s
+%A
+[30;42mOK (1 test, 1 assertion)[0m

--- a/test/functional/notice silenced.phpt
+++ b/test/functional/notice silenced.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Tests that when a test generates a notice that is suppressed, the notice is not printed.
+
+--ARGS--
+-c test --colors=always test/CapabilitiesTest.php --filter ::testSilencedNotice$
+
+--FILE_EXTERNAL--
+../PHPUnit runner.php
+
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s
+
+100% . [32;1mScriptFUSIONTest\Pip\CapabilitiesTest::testSilencedNotice[0m [32m(%d ms)[0m
+
+
+Time: %s
+%A
+[30;42mOK (1 test, 1 assertion)[0m

--- a/test/functional/warning silenced.phpt
+++ b/test/functional/warning silenced.phpt
@@ -13,7 +13,7 @@ PHPUnit %s
 Runtime: %s
 Configuration: %s
 
-100% [33;1mW[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testSilencedWarning[0m [32m(%d ms)[0m
+100% . [32;1mScriptFUSIONTest\Pip\CapabilitiesTest::testSilencedWarning[0m [32m(%d ms)[0m
 
 
 Time: %s


### PR DESCRIPTION
Warnings suppressed with `@` were still altering the test status.

This is still not a full solution, because status is assigned separately for each error severity and I've only changed warnings. I wanted to get some feedback before spending more time on this.