### PR TITLE
Fix #19 - Print all error messages

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -85,6 +85,7 @@ final class Printer implements Tracer
                 $this->status = TestStatus::Risky;
             }
 
+            // No duplicate handling needed. Risky is a test status (rather than issue status) and it's final.
             $this->uniqueTraces[] = new Trace(TestStatus::Risky, $event->message(), $event->test()->file(), $event->test()->line());
         }
         if ($event instanceof PhpNoticeTriggered) {

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -32,12 +32,20 @@ final class Printer implements Tracer
 
     private ?Throwable $throwable = null;
 
-    private ?Trace $trace = null;
+    /**
+     * @var array<string, Trace>
+     */
+    private array $uniqueTraces = [];
 
     private bool $flawless = true;
 
     public function __construct(private readonly PipConfig $config)
     {
+    }
+
+    private function addUniqueTrace(Trace $trace): void
+    {
+        $this->uniqueTraces[$trace->getIssueId()] = $trace;
     }
 
     public function trace(Event $event): void
@@ -77,28 +85,28 @@ final class Printer implements Tracer
                 $this->status = TestStatus::Risky;
             }
 
-            $this->trace = new Trace($event->message(), $event->test()->file(), $event->test()->line());
+            $this->uniqueTraces[] = new Trace(TestStatus::Risky, $event->message(), $event->test()->file(), $event->test()->line());
         }
         if ($event instanceof PhpNoticeTriggered) {
             if (!$event->wasSuppressed()) {
                 $this->status ??= TestStatus::Notice;
             }
 
-            $this->trace = Trace::fromEvent($event);
+            $this->addUniqueTrace(Trace::fromEvent($event));
         }
         if ($event instanceof PhpWarningTriggered) {
             if (!$event->wasSuppressed()) {
                 $this->status ??= TestStatus::Warning;
             }
 
-            $this->trace = Trace::fromEvent($event);
+            $this->addUniqueTrace(Trace::fromEvent($event));
         }
         if ($event instanceof PhpDeprecationTriggered) {
             if (!$event->wasSuppressed()) {
                 $this->status ??= TestStatus::Deprecated;
             }
 
-            $this->trace = Trace::fromEvent($event);
+            $this->addUniqueTrace(Trace::fromEvent($event));
         }
 
         if ($event instanceof Finished) {
@@ -135,10 +143,11 @@ final class Printer implements Tracer
                 $ms,
                 $performance,
                 $this->throwable,
-                $this->trace,
+                $this->uniqueTraces
             ));
 
-            $this->trace = $this->throwable = $this->status = null;
+            $this->uniqueTraces = [];
+            $this->throwable = $this->status = null;
         }
 
         if ($event instanceof \PHPUnit\Event\TestRunner\Finished) {

--- a/src/TestResult.php
+++ b/src/TestResult.php
@@ -15,7 +15,8 @@ final class TestResult
         public readonly int $testDurationMs,
         public readonly TestPerformance $testPerformance,
         public readonly ?Throwable $throwable,
-        public readonly ?Trace $trace,
+        /** @var array<string, Trace> */
+        public readonly array $uniqueTraces,
     ) {
     }
 

--- a/src/Theme/ClassicTheme.php
+++ b/src/Theme/ClassicTheme.php
@@ -46,8 +46,8 @@ final class ClassicTheme implements Theme
             $throwable = $throwable->previous();
         }
 
-        $firstIssue = true;
-        foreach ($result->uniqueTraces as $trace) {
+        $lastKey = array_key_last($result->uniqueTraces);
+        foreach ($result->uniqueTraces as $key => $trace) {
             if (!$trace->suppressed) {
                 $issueStatusColour = self::getColour($trace->issueStatus);
                 printf(
@@ -57,10 +57,9 @@ final class ClassicTheme implements Theme
                     $trace->message,
                     $trace->file,
                     $trace->line,
-                    $firstIssue ? PHP_EOL . PHP_EOL : PHP_EOL,
+                    $key === $lastKey ? PHP_EOL . PHP_EOL : PHP_EOL,
                 );
             }
-            $firstIssue = false;
         }
     }
 

--- a/src/Theme/ClassicTheme.php
+++ b/src/Theme/ClassicTheme.php
@@ -46,15 +46,21 @@ final class ClassicTheme implements Theme
             $throwable = $throwable->previous();
         }
 
-        if ($result->trace && !$result->trace->suppressed) {
-            printf(
-                Color::colorize("fg-$statusColour", '%s%s: %s in %s on line %s%1$s%1$s'),
-                PHP_EOL,
-                $result->status->name,
-                $result->trace->message,
-                $result->trace->file,
-                $result->trace->line,
-            );
+        $firstIssue = true;
+        foreach ($result->uniqueTraces as $trace) {
+            if (!$trace->suppressed) {
+                $issueStatusColour = self::getColour($trace->issueStatus);
+                printf(
+                    Color::colorize("fg-$issueStatusColour", '%s%s: %s in %s on line %d%s'),
+                    PHP_EOL,
+                    $trace->issueStatus->name,
+                    $trace->message,
+                    $trace->file,
+                    $trace->line,
+                    $firstIssue ? PHP_EOL . PHP_EOL : PHP_EOL,
+                );
+            }
+            $firstIssue = false;
         }
     }
 

--- a/src/Theme/ClassicTheme.php
+++ b/src/Theme/ClassicTheme.php
@@ -7,6 +7,7 @@ use PHPUnit\Util\Color;
 use ScriptFUSION\Pip\TestPerformance;
 use ScriptFUSION\Pip\TestResult;
 use ScriptFUSION\Pip\TestStatus;
+use ScriptFUSION\Pip\Trace;
 
 final class ClassicTheme implements Theme
 {
@@ -46,19 +47,20 @@ final class ClassicTheme implements Theme
             $throwable = $throwable->previous();
         }
 
-        $lastKey = array_key_last($result->uniqueTraces);
-        foreach ($result->uniqueTraces as $key => $trace) {
+        $firstIssue = true;
+        foreach ($result->uniqueTraces as $trace) {
             if (!$trace->suppressed) {
                 $issueStatusColour = self::getColour($trace->issueStatus);
                 printf(
                     Color::colorize("fg-$issueStatusColour", '%s%s: %s in %s on line %d%s'),
-                    PHP_EOL,
+                    $firstIssue ? PHP_EOL : '',
                     $trace->issueStatus->name,
                     $trace->message,
                     $trace->file,
                     $trace->line,
-                    $key === $lastKey ? PHP_EOL . PHP_EOL : PHP_EOL,
+                    PHP_EOL . PHP_EOL,
                 );
+                $firstIssue = false;
             }
         }
     }

--- a/src/Trace.php
+++ b/src/Trace.php
@@ -19,12 +19,17 @@ final class Trace
 
     public static function fromEvent(PhpWarningTriggered|PhpNoticeTriggered|PhpDeprecationTriggered $event): self
     {
-        $issueStatus = match (true) {
-            $event instanceof PhpWarningTriggered => TestStatus::Warning,
-            $event instanceof PhpNoticeTriggered => TestStatus::Notice,
-            $event instanceof PhpDeprecationTriggered => TestStatus::Deprecated,
-        };
-        return new self($issueStatus, $event->message(), $event->file(), $event->line(), $event->wasSuppressed());
+        return new self(
+            match (true) {
+                $event instanceof PhpWarningTriggered => TestStatus::Warning,
+                $event instanceof PhpNoticeTriggered => TestStatus::Notice,
+                $event instanceof PhpDeprecationTriggered => TestStatus::Deprecated,
+            },
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+        );
     }
 
     /**

--- a/src/Trace.php
+++ b/src/Trace.php
@@ -34,13 +34,11 @@ final class Trace
      */
     public function getIssueId(): string
     {
-        return sha1(
-            sprintf(
-                '%s:%s:%s',
-                $this->file,
-                $this->line,
-                $this->message,
-            ),
+        return sprintf(
+            '%s:%s:%s',
+            $this->file,
+            $this->line,
+            $this->message,
         );
     }
 }

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -130,8 +130,7 @@ final class CapabilitiesTest extends TestCase
     {
         // Notice.
         $foo = &self::provideData();
-        // Warning.
-        foreach (1 as $n) {}
+        $this->triggerWarning();
         // Deprecated.
         trim(null);
 

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -138,9 +138,6 @@ final class CapabilitiesTest extends TestCase
         // Deprecated.
         trim(null);
 
-        // Silenced warning.
-        $foo = @$bar;
-
         self::assertTrue(true);
     }
 

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -128,15 +128,22 @@ final class CapabilitiesTest extends TestCase
 
     public function testMixedSeverities(): void
     {
-        // Silenced warning.
-        $foo = @$bar;
-
         // Notice.
         $foo = &self::provideData();
         // Warning.
         foreach (1 as $n) {}
         // Deprecated.
         trim(null);
+
+        self::assertTrue(true);
+    }
+
+    public function testSilencedWarningNotAffectsStatus(): void
+    {
+        $foo = @$bar;
+
+        // Notice.
+        $foo = &self::provideData();
 
         self::assertTrue(true);
     }

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -126,6 +126,24 @@ final class CapabilitiesTest extends TestCase
         self::assertTrue(true);
     }
 
+    public function testMixedSeverities(): void
+    {
+        // Silenced warning.
+        $foo = @$bar;
+
+        // Notice.
+        $foo = &self::provideData();
+        // Warning.
+        foreach (1 as $n) {}
+        // Deprecated.
+        trim(null);
+
+        // Silenced warning.
+        $foo = @$bar;
+
+        self::assertTrue(true);
+    }
+
     #[DataProvider('provideData')]
 
     public function testDataProvider(): void

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -98,6 +98,34 @@ final class CapabilitiesTest extends TestCase
         self::assertTrue(true);
     }
 
+    private function triggerWarning(): void
+    {
+        foreach (1 as $n) {}
+    }
+
+    public function testDuplicateWarningsA(): void
+    {
+        $this->triggerWarning();
+
+        self::assertTrue(true);
+    }
+
+    public function testDuplicateWarningsB(): void
+    {
+        $this->triggerWarning();
+        $this->triggerWarning();
+        $this->triggerWarning();
+
+        foreach (1 as $n) {}
+
+        self::assertTrue(true);
+    }
+
+    public function testDuplicateWarningsC(): void
+    {
+        self::assertTrue(true);
+    }
+
     #[DataProvider('provideData')]
 
     public function testDataProvider(): void

--- a/test/CapabilitiesTest.php
+++ b/test/CapabilitiesTest.php
@@ -140,7 +140,7 @@ final class CapabilitiesTest extends TestCase
 
     public function testSilencedWarningNotAffectsStatus(): void
     {
-        $foo = @$bar;
+        @$this->triggerWarning();
 
         // Notice.
         $foo = &self::provideData();

--- a/test/functional/duplicate warnings.phpt
+++ b/test/functional/duplicate warnings.phpt
@@ -1,0 +1,30 @@
+--TEST--
+PHPUnit only reports warnings with globally unique locations within executed tests.
+
+--ARGS--
+-c test --colors=always test/CapabilitiesTest.php --filter ::testDuplicateWarnings
+
+--FILE_EXTERNAL--
+../PHPUnit runner.php
+
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s
+
+ 33% [33;1mW[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsA[0m [32m(%d ms)[0m
+[33;1m
+Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
+
+[0m 66% [33;1mW[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsB[0m [32m(%d ms)[0m
+[33;1m
+Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
+
+[0m100% . [32;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsC[0m [32m(%d ms)[0m
+
+
+Time: %s
+%A
+[30;43mOK, but %s![0m
+[30;43mTests: 3[0m[30;43m, Assertions: 3[0m[30;43m, Warnings: 2[0m[30;43m.[0m

--- a/test/functional/duplicate warnings.phpt
+++ b/test/functional/duplicate warnings.phpt
@@ -21,6 +21,8 @@ Warning: foreach() argument must be of type array|object, int given in %s%eCapab
 [33;1m
 Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
 
+[0m[33;1m
+Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
 [0m100% . [32;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsC[0m [32m(%d ms)[0m
 
 

--- a/test/functional/duplicate warnings.phpt
+++ b/test/functional/duplicate warnings.phpt
@@ -20,8 +20,8 @@ Warning: foreach() argument must be of type array|object, int given in %s%eCapab
 [0m 66% [33;1mW[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsB[0m [32m(%d ms)[0m
 [33;1m
 Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
-[0m[33;1m
-Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
+
+[0m[33;1mWarning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
 
 [0m100% . [32;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsC[0m [32m(%d ms)[0m
 

--- a/test/functional/duplicate warnings.phpt
+++ b/test/functional/duplicate warnings.phpt
@@ -20,9 +20,9 @@ Warning: foreach() argument must be of type array|object, int given in %s%eCapab
 [0m 66% [33;1mW[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsB[0m [32m(%d ms)[0m
 [33;1m
 Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
-
 [0m[33;1m
 Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
+
 [0m100% . [32;1mScriptFUSIONTest\Pip\CapabilitiesTest::testDuplicateWarningsC[0m [32m(%d ms)[0m
 
 

--- a/test/functional/mixed severities.phpt
+++ b/test/functional/mixed severities.phpt
@@ -17,10 +17,11 @@ Configuration: %s
 100% [33;1mN[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testMixedSeverities[0m [32m(%d ms)[0m
 [33;1m
 Notice: Only variables should be assigned by reference in %s%eCapabilitiesTest.php on line %d
-[0m[33;1m
-Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
-[0m[33;1m
-Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in %s%eCapabilitiesTest.php on line %d
+
+[0m[33;1mWarning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
+
+[0m[33;1mDeprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in %s%eCapabilitiesTest.php on line %d
+
 [0m
 
 Time: %s

--- a/test/functional/mixed severities.phpt
+++ b/test/functional/mixed severities.phpt
@@ -1,0 +1,29 @@
+--TEST--
+When a test generates errors with different severities and silences some of them, first non-silenced error determines
+overall test status and all non-silenced messages are shown.
+
+--ARGS--
+-c test --colors=always test/CapabilitiesTest.php --filter ::testMixedSeverities$
+
+--FILE_EXTERNAL--
+../PHPUnit runner.php
+
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s
+
+100% [33;1mN[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testMixedSeverities[0m [32m(%d ms)[0m
+[33;1m
+Notice: Only variables should be assigned by reference in %s%eCapabilitiesTest.php on line %d
+[0m[33;1m
+Warning: foreach() argument must be of type array|object, int given in %s%eCapabilitiesTest.php on line %d
+[0m[33;1m
+Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in %s%eCapabilitiesTest.php on line %d
+[0m
+
+Time: %s
+%A
+[30;43mOK, but %s![0m
+[30;43mTests: 1[0m[30;43m, Assertions: 1[0m[30;43m, Warnings: 1[0m[30;43m, Deprecations: 1[0m[30;43m, Notices: 1[0m[30;43m.[0m

--- a/test/functional/status notice warning silenced.phpt
+++ b/test/functional/status notice warning silenced.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test that first notice determines test status and prior silenced warning does not.
+
+--ARGS--
+-c test --colors=always test/CapabilitiesTest.php --filter ::testSilencedWarningNotAffectsStatus$
+
+--FILE_EXTERNAL--
+../PHPUnit runner.php
+
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s
+
+100% [33;1mN[0m [33;1mScriptFUSIONTest\Pip\CapabilitiesTest::testSilencedWarningNotAffectsStatus[0m [32m(%d ms)[0m
+[33;1m
+Notice: Only variables should be assigned by reference in %s%eCapabilitiesTest.php on line %d
+
+[0m
+
+Time: %s
+%A
+[30;43mOK, but %s![0m
+[30;43mTests: 1[0m[30;43m, Assertions: 1[0m[30;43m, Notices: 1[0m[30;43m.[0m


### PR DESCRIPTION
Changes for warnings/notices/exceptions (aka issues) handling:

- Test that duplicate issues only count as one in the summary. (Standard PHPUnit behaviour, it was working fine so no changes were needed).
- Fixed test status (caused by first issue) being incorrectly assigned to last issue.
- Display all issues at test level, save for duplicates within test.

PHPUnit determines uniqueness by comparing file, line and message. I've followed the same criteria.

![::testDuplicateWarnings](https://github.com/user-attachments/assets/46d23266-53c1-4e64-9706-526758e5071e)

![::testMixedSeverities](https://github.com/user-attachments/assets/54137620-6b32-4d6e-aadf-48ca0c1af093)

